### PR TITLE
Fix 'New Quest' square to load new quest modal

### DIFF
--- a/fuel/app/views/user/dashboard.php
+++ b/fuel/app/views/user/dashboard.php
@@ -34,7 +34,7 @@
 								<div class="added-by">
 									&nbsp;
 								</div>
-								<a style="border: 2px dashed #aaa; background-image:url(/assets/img/add-quest.png)" href="#addProductModal" class="dash-product-image-div" data-toggle="modal">
+								<a style="border: 2px dashed #aaa; background-image:url(/assets/img/add-quest.png)" href="#questModal" class="dash-product-image-div" data-toggle="modal">
 								</a>
 							</div>
 					</div>


### PR DESCRIPTION
The 'New Quest' Square is currently not loading the new quest Modul when you click on it.
