### PR TITLE
Remove "Contact us with" text on email template

### DIFF
--- a/fuel/app/views/emails/template.php
+++ b/fuel/app/views/emails/template.php
@@ -10,7 +10,6 @@
 		Chicago, IL  60654
 	</div>
 	<div style="width: 50%;">
-		Contact us with
 		<a href="http://facebook.com/shopgab"><img src="http://shopgab.com/assets/email/facebook.png"></a>
 		<a href="http://twitter.com/weshopgab"><img src="http://shopgab.com/assets/email/twitter.png"></a>
 		<a href="http://pinterest.com/WeShopGab/boards/"><img src="http://shopgab.com/assets/email/pinterest.png"></a>


### PR DESCRIPTION
Text is pushing social media icons to the side and making it look funky.
