### PR TITLE
facebook share won't work due to no-product.png

### DIFF
--- a/fuel/app/classes/model/quest.php
+++ b/fuel/app/classes/model/quest.php
@@ -180,7 +180,7 @@ class Model_Quest extends \Orm\Model
 			}
 		}
 
-		return "assets/img/no-product.png";
+		return Uri::create("assets/img/no-product.png");
 	}
 
 


### PR DESCRIPTION
url issue with no-product.png causing facebook to reject 
